### PR TITLE
fix "default" priorPosterior plot

### DIFF
--- a/R/commonbayesianttest.R
+++ b/R/commonbayesianttest.R
@@ -452,10 +452,10 @@
 
     # ensure that BF type is correct (e.g., BF01 to BF10/ log(BF01))
     ttestRows[["BF"]] <-
-      .recodeBFtype(bfOld     = ttestRows[["BF"]],
-                    newBFtype = options[["bayesFactorType"]],
-                    oldBFtype = ttestState[["bayesFactorType"]]
-      )
+      JASP:::.recodeBFtype(bfOld     = ttestRows[["BF"]],
+                           newBFtype = options[["bayesFactorType"]],
+                           oldBFtype = ttestState[["bayesFactorType"]]
+                           )
   }
   return(ttestRows)
 }
@@ -1790,7 +1790,7 @@
     # informative prior
     xlim <- vector("numeric", 2)
 
-    if(options[["effectSize"]] == "standardized"){
+    if(options[["effectSizeStandardized"]] == "default"){
       
       ci99PlusMedian <- .ciPlusMedian_t(t = t, n1 = n1, n2 = n2, independentSamples = ! paired && !is.null(n2),
                                         prior.location = 0,

--- a/R/informedbayesianttestfunctions.R
+++ b/R/informedbayesianttestfunctions.R
@@ -40,20 +40,28 @@
 }
 
 .dprior_informative <- function(delta, oneSided = FALSE, options) {
-
-  if (options[["informativeStandardizedEffectSize"]] == "cauchy") {
-    out <- .dtss(delta, mu.delta = options[["informativeCauchyLocation"]],
-                 r = options[["informativeCauchyScale"]],
-                 kappa = 1)
+  isDefault <- options[["effectSizeStandardized"]] == "default"
+  
+  if(isDefault) {
+    cauchyLocation <- 0
+    cauchyScale    <- options[["priorWidth"]]
+  } else {
+    cauchyLocation <- options[["informativeCauchyLocation"]] 
+    cauchyScale    <- options[["informativeCauchyScale"]]
+  }
+  
+  if (options[["informativeStandardizedEffectSize"]] == "cauchy" || isDefault) {
+    out <- .dtss(delta, mu.delta = cauchyLocation, r = cauchyScale, kappa = 1)
+    
     if (oneSided == "right") {
       out <- ifelse(delta < 0, 0, out/integrate(.dtss, 0, Inf,
-                                                mu.delta = options[["informativeCauchyLocation"]],
-                                                r = options[["informativeCauchyScale"]],
+                                                mu.delta = cauchyLocation,
+                                                r = cauchyScale,
                                                 kappa = 1)$value)
     } else if (oneSided == "left") {
       out <- ifelse(delta > 0, 0, out/integrate(.dtss, -Inf, 0,
-                                                mu.delta = options[["informativeCauchyLocation"]],
-                                                r = options[["informativeCauchyScale"]],
+                                                mu.delta = cauchyLocation,
+                                                r = cauchyScale,
                                                 kappa = 1)$value)
     }
   } else if (options[["informativeStandardizedEffectSize"]] == "t") {
@@ -268,23 +276,33 @@
 }
 
 .dposterior_informative <- function(delta, t, n1, n2 = NULL, paired = FALSE, oneSided = FALSE, options) {
-
-  if (options[["informativeStandardizedEffectSize"]] == "cauchy") {
+  isDefault <- options[["effectSizeStandardized"]] == "default"
+  
+  if(isDefault) {
+    cauchyLocation <- 0
+    cauchyScale    <- options[["priorWidth"]]
+  } else {
+    cauchyLocation <- options[["informativeCauchyLocation"]] 
+    cauchyScale    <- options[["informativeCauchyScale"]]
+  }
+  
+  
+  if (options[["informativeStandardizedEffectSize"]] == "cauchy" || isDefault) {
     out <- .posterior_t(delta, t = t, n1 = n1, n2 = n2, independentSamples = ! paired && !is.null(n2),
-                        prior.location = options[["informativeCauchyLocation"]],
-                        prior.scale = options[["informativeCauchyScale"]],
+                        prior.location = cauchyLocation,
+                        prior.scale    = cauchyScale,
                         prior.df = 1)
     if (oneSided == "right") {
 
       out <- ifelse(delta < 0, 0, out / (1 - .cdf_t(0, t = t, n1 = n1, n2 = n2, independentSamples = ! paired && !is.null(n2),
-                                                    prior.location = options[["informativeCauchyLocation"]],
-                                                    prior.scale = options[["informativeCauchyScale"]],
+                                                    prior.location = cauchyLocation,
+                                                    prior.scale    = cauchyScale,
                                                     prior.df = 1)))
     } else if (oneSided == "left") {
 
       out <- ifelse(delta > 0, 0, out / .cdf_t(0, t = t, n1 = n1, n2 = n2, independentSamples = ! paired && !is.null(n2),
-                                               prior.location = options[["informativeCauchyLocation"]],
-                                               prior.scale = options[["informativeCauchyScale"]],
+                                               prior.location = cauchyLocation,
+                                               prior.scale    = cauchyScale,
                                                prior.df = 1))
     }
   } else if (options[["informativeStandardizedEffectSize"]] == "t") {

--- a/R/ttestbayesianindependentsamples.R
+++ b/R/ttestbayesianindependentsamples.R
@@ -168,7 +168,7 @@ TTestBayesianIndependentSamples <- function(jaspResults, dataset, options) {
       }
 
       ttestResults[["BF10post"]][var] <- bf.raw
-      BF <- .recodeBFtype(bfOld     = bf.raw,
+      BF <- JASP:::.recodeBFtype(bfOld     = bf.raw,
                           newBFtype = options[["bayesFactorType"]],
                           oldBFtype = "BF10"
       )


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-issues/issues/730

The bug was a little bit elusive, in the end it was caused by:

1) assuming that "default" prior is in defined as `effectSize == "standardized"` in `SubjectivePriors.qml`, whereas it is actually defined as `effectSizeStandardized == "default"` (this caused informative priors having "default" CIs in the plots)

2) functions `.dprior_informative()` and `.dposterior_informative()` not having a condition for "default" prior, which lead to using location of the Cauchy from the informative prior by default (therefore, the "default" prior no longer switched to location = 0 when the informative Cauchy was specified to other value).

@vandenman I assigned you in case you have time for this by chance, otherwise suggest someone else for a review...